### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.2.0-SNAPSHOT
+## 2.2.0
 * create `ItemGroup` for easier nested RecyclerView support
 * create `ItemLayoutWrapper` for easier wrapping of an `Item` inside a different layout
 * add `HasWrappedItem` interface (2 implementations - `ItemWrapper` and `ItemLayoutWrapper`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 * create `ItemLayoutWrapper` for easier wrapping of an `Item` inside a different layout
 * add `HasWrappedItem` interface (2 implementations - `ItemWrapper` and `ItemLayoutWrapper`)
 * utility to automatically process nested RecyclerView state - `NestedRecyclerState`
+* add `Adapt#getItem(position)` method
+* add `AdaptView#view()` method
+* add `StickyItemDecoration` for sticky headers/sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 2.2.0-SNAPSHOT
+* create `ItemGroup` for easier nested RecyclerView support
+* create `ItemLayoutWrapper` for easier wrapping of an `Item` inside a different layout
+* add `HasWrappedItem` interface (2 implementations - `ItemWrapper` and `ItemLayoutWrapper`)
+* utility to automatically process nested RecyclerView state - `NestedRecyclerState`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Adapt
 
-`RecyclerView.Adapter` only shorter. Abstraction to create re-usable components that can be used inside RecyclerView, ViewGroup or be bound to a View directly.
+`RecyclerView.Adapter` only shorter. Abstraction to create re-usable components that can be used inside RecyclerView, ViewGroup or be bound to a View directly. 
 
 ![sample-gif](art/sample.gif)
+![sample-gif-220](art/sample-220.gif)
 
 ## Install
 

--- a/adapt/src/main/java/io/noties/adapt/Adapt.java
+++ b/adapt/src/main/java/io/noties/adapt/Adapt.java
@@ -190,6 +190,15 @@ public class Adapt extends RecyclerView.Adapter<Item.Holder> {
         return safeList(items).size();
     }
 
+    /**
+     * @param position of item
+     * @since 2.2.0-SNAPSHOT
+     */
+    @NonNull
+    public Item getItem(int position) {
+        return items.get(position);
+    }
+
     public void setItems(@Nullable List<Item> items) {
         setItems(items, null);
     }

--- a/adapt/src/main/java/io/noties/adapt/Adapt.java
+++ b/adapt/src/main/java/io/noties/adapt/Adapt.java
@@ -192,7 +192,7 @@ public class Adapt extends RecyclerView.Adapter<Item.Holder> {
 
     /**
      * @param position of item
-     * @since 2.2.0-SNAPSHOT
+     * @since 2.2.0
      */
     @NonNull
     public Item getItem(int position) {

--- a/adapt/src/main/java/io/noties/adapt/AdaptView.java
+++ b/adapt/src/main/java/io/noties/adapt/AdaptView.java
@@ -91,6 +91,12 @@ public abstract class AdaptView<I extends Item> {
     @NonNull
     public abstract I getCurrentItem();
 
+    /**
+     * @since 2.2.0-SNAPSHOT
+     */
+    @NonNull
+    public abstract View view();
+
 
     static class Impl<I extends Item> extends AdaptView<I> {
 
@@ -138,6 +144,12 @@ public abstract class AdaptView<I extends Item> {
                         "view: %s", view);
             }
             return currentItem;
+        }
+
+        @NonNull
+        @Override
+        public View view() {
+            return view;
         }
     }
 }

--- a/adapt/src/main/java/io/noties/adapt/AdaptView.java
+++ b/adapt/src/main/java/io/noties/adapt/AdaptView.java
@@ -92,7 +92,7 @@ public abstract class AdaptView<I extends Item> {
     public abstract I getCurrentItem();
 
     /**
-     * @since 2.2.0-SNAPSHOT
+     * @since 2.2.0
      */
     @NonNull
     public abstract View view();

--- a/adapt/src/main/java/io/noties/adapt/HasWrappedItem.java
+++ b/adapt/src/main/java/io/noties/adapt/HasWrappedItem.java
@@ -1,0 +1,16 @@
+package io.noties.adapt;
+
+import androidx.annotation.NonNull;
+
+/**
+ * A common interface for item wrappers.
+ *
+ * @see ItemWrapper
+ * @see ItemLayoutWrapper
+ * @since 2.2.0-SNAPSHOT
+ */
+public interface HasWrappedItem<H extends Item.Holder> {
+
+    @NonNull
+    Item<H> item();
+}

--- a/adapt/src/main/java/io/noties/adapt/HasWrappedItem.java
+++ b/adapt/src/main/java/io/noties/adapt/HasWrappedItem.java
@@ -7,7 +7,7 @@ import androidx.annotation.NonNull;
  *
  * @see ItemWrapper
  * @see ItemLayoutWrapper
- * @since 2.2.0-SNAPSHOT
+ * @since 2.2.0
  */
 public interface HasWrappedItem<H extends Item.Holder> {
 

--- a/adapt/src/main/java/io/noties/adapt/ItemGroup.java
+++ b/adapt/src/main/java/io/noties/adapt/ItemGroup.java
@@ -15,7 +15,7 @@ import java.util.List;
  * <p>
  * Please note that this item automatically takes care
  *
- * @since 2.2.0-SNAPSHOT
+ * @since 2.2.0
  */
 public abstract class ItemGroup extends Item<ItemGroup.Holder> {
 

--- a/adapt/src/main/java/io/noties/adapt/ItemGroup.java
+++ b/adapt/src/main/java/io/noties/adapt/ItemGroup.java
@@ -1,0 +1,112 @@
+package io.noties.adapt;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
+
+/**
+ * Class to allow nested RecyclerView. Please note that each unique group must have a dedicated subclass
+ * in order to have a unique view-type.
+ * <p>
+ * Please note that this item automatically takes care
+ *
+ * @since 2.2.0-SNAPSHOT
+ */
+public abstract class ItemGroup extends Item<ItemGroup.Holder> {
+
+    // should we allow mutation, how to trigger notification then?
+    private List<Item> children;
+
+    protected ItemGroup(long id, @NonNull List<Item> children) {
+        super(id);
+        this.children = children;
+    }
+
+    @NonNull
+    public List<Item> getChildren() {
+        return children;
+    }
+
+    /**
+     * Please note that item has no means to invalidate parent recycler-view. This is why, if
+     * you call this method make sure to manually dispatch update notification
+     *
+     * @param children a new set of children for this group
+     */
+    public void setChildren(@NonNull List<Item> children) {
+        this.children = children;
+    }
+
+    @NonNull
+    @Override
+    public Holder createHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent) {
+
+        final View view = createView(inflater, parent);
+        final RecyclerView recyclerView = initNestedRecyclerView(view);
+        final Adapt adapt = createNestedAdapt();
+
+        processRecyclerViewPool(parent, recyclerView);
+
+        // set adapter
+        recyclerView.setAdapter(adapt);
+
+        return new Holder(view, recyclerView, adapt);
+    }
+
+    @Override
+    public void render(@NonNull Holder holder) {
+        holder.adapt.setItems(children);
+
+        processState(holder);
+    }
+
+    @NonNull
+    protected abstract View createView(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent);
+
+    /**
+     * Initialize recycler-view in view created by {@link #createView(LayoutInflater, ViewGroup)} call.
+     * Here everything must be prepared for a recycler-view to be used (LayoutManager, animations,
+     * decorations, etc)
+     */
+    @NonNull
+    protected abstract RecyclerView initNestedRecyclerView(@NonNull View view);
+
+    /**
+     * Create an {@link Adapt} instance for nested recycler-view.
+     */
+    @NonNull
+    protected Adapt createNestedAdapt() {
+        return Adapt.create();
+    }
+
+    protected void processRecyclerViewPool(@NonNull ViewGroup parent, @NonNull RecyclerView recyclerView) {
+        // if parent is a recycler-view -> share the recycler pool
+        // this item-group can still be displayed in a regular view-group
+        if (parent instanceof RecyclerView) {
+            recyclerView.setRecycledViewPool(((RecyclerView) parent).getRecycledViewPool());
+        }
+    }
+
+    protected void processState(@NonNull Holder holder) {
+        NestedRecyclerState
+                .process(id(), holder.recyclerView);
+    }
+
+    protected static class Holder extends Item.Holder {
+
+        public final RecyclerView recyclerView;
+        public final Adapt adapt;
+
+        protected Holder(@NonNull View itemView, @NonNull RecyclerView recyclerView, @NonNull Adapt adapt) {
+            super(itemView);
+
+            this.recyclerView = recyclerView;
+            this.adapt = adapt;
+        }
+    }
+}

--- a/adapt/src/main/java/io/noties/adapt/ItemLayoutWrapper.java
+++ b/adapt/src/main/java/io/noties/adapt/ItemLayoutWrapper.java
@@ -1,0 +1,89 @@
+package io.noties.adapt;
+
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * A wrapper to put {@link Item} view inside another layout. Please note that this wrapper
+ * uses supplied item {@code viewType} so make sure that all items of the same type is wrapped
+ * with the same ItemLayoutWrapper.
+ *
+ * @since 2.2.0-SNAPSHOT
+ */
+public class ItemLayoutWrapper<H extends Item.Holder>
+        extends Item<ItemLayoutWrapper.Holder> implements HasWrappedItem<H> {
+
+    /**
+     * @param layout resource to wrap supplied {@code item}, root view tag must be a ViewGroup
+     * @param item   to wrap
+     */
+    @NonNull
+    public static <H extends Item.Holder> ItemLayoutWrapper<H> create(
+            @LayoutRes int layout,
+            @NonNull Item<H> item) {
+        return new ItemLayoutWrapper<>(layout, item);
+    }
+
+    private final int layout;
+    private final Item<H> item;
+
+    @SuppressWarnings("WeakerAccess")
+    public ItemLayoutWrapper(@LayoutRes int layout, @NonNull Item<H> item) {
+        super(item.id());
+        this.layout = layout;
+        this.item = item;
+    }
+
+    @NonNull
+    @Override
+    public Holder createHolder(@NonNull LayoutInflater inflater, @NonNull ViewGroup parent) {
+        final ViewGroup root = (ViewGroup) inflater.inflate(layout, parent, false);
+        return new Holder(root, item.createHolder(inflater, root));
+    }
+
+    @Override
+    public void render(@NonNull Holder holder) {
+        //noinspection unchecked
+        item.render((H) holder.wrapped);
+    }
+
+    @Override
+    public int viewType() {
+        return item.viewType();
+    }
+
+    @Nullable
+    @Override
+    public RecyclerView.ItemDecoration recyclerDecoration(@NonNull RecyclerView recyclerView) {
+        return item.recyclerDecoration(recyclerView);
+    }
+
+    @NonNull
+    @Override
+    public Item<H> item() {
+        return item;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    protected static class Holder extends Item.Holder {
+
+        protected final Item.Holder wrapped;
+
+        protected Holder(@NonNull ViewGroup itemView, @NonNull Item.Holder wrapped) {
+            super(itemView);
+            this.wrapped = wrapped;
+
+            appendWrappedView(itemView, wrapped);
+        }
+
+        protected void appendWrappedView(@NonNull ViewGroup group, @NonNull Item.Holder wrapped) {
+            // manually add wrapped item view
+            group.addView(wrapped.itemView);
+        }
+    }
+}

--- a/adapt/src/main/java/io/noties/adapt/ItemLayoutWrapper.java
+++ b/adapt/src/main/java/io/noties/adapt/ItemLayoutWrapper.java
@@ -13,7 +13,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * uses supplied item {@code viewType} so make sure that all items of the same type is wrapped
  * with the same ItemLayoutWrapper.
  *
- * @since 2.2.0-SNAPSHOT
+ * @since 2.2.0
  */
 public class ItemLayoutWrapper<H extends Item.Holder>
         extends Item<ItemLayoutWrapper.Holder> implements HasWrappedItem<H> {

--- a/adapt/src/main/java/io/noties/adapt/ItemWrapper.java
+++ b/adapt/src/main/java/io/noties/adapt/ItemWrapper.java
@@ -12,12 +12,15 @@ import androidx.recyclerview.widget.RecyclerView;
  * by default will use own \'recyclerViewType\' in order to distinguish from original (wrapped) item.
  * Other methods {@link #createHolder(LayoutInflater, ViewGroup)}, {@link #render(Holder)},
  * {@link #recyclerDecoration(RecyclerView)} are calling
- * original item. Ids are shared (the same for original and wrapped (this) items)
+ * original item. Ids are shared (the same for original and wrapped (this) items).
+ * <p>
+ * Since 2.2.0-SNAPSHOT implements {@link HasWrappedItem}
  *
  * @see OnClickWrapper
  * @since 2.0.0
  */
-public class ItemWrapper<H extends Item.Holder> extends Item<H> {
+public class ItemWrapper<H extends Item.Holder>
+        extends Item<H> implements HasWrappedItem<H> {
 
     private final Item<H> item;
 
@@ -26,7 +29,11 @@ public class ItemWrapper<H extends Item.Holder> extends Item<H> {
         this.item = item;
     }
 
+    /**
+     * @since 2.2.0-SNAPSHOT this method comes from {@link HasWrappedItem} interface
+     */
     @NonNull
+    @Override
     public Item<H> item() {
         return item;
     }

--- a/adapt/src/main/java/io/noties/adapt/ItemWrapper.java
+++ b/adapt/src/main/java/io/noties/adapt/ItemWrapper.java
@@ -14,7 +14,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * {@link #recyclerDecoration(RecyclerView)} are calling
  * original item. Ids are shared (the same for original and wrapped (this) items).
  * <p>
- * Since 2.2.0-SNAPSHOT implements {@link HasWrappedItem}
+ * Since 2.2.0 implements {@link HasWrappedItem}
  *
  * @see OnClickWrapper
  * @since 2.0.0
@@ -30,7 +30,7 @@ public class ItemWrapper<H extends Item.Holder>
     }
 
     /**
-     * @since 2.2.0-SNAPSHOT this method comes from {@link HasWrappedItem} interface
+     * @since 2.2.0 this method comes from {@link HasWrappedItem} interface
      */
     @NonNull
     @Override

--- a/adapt/src/main/java/io/noties/adapt/NestedRecyclerState.java
+++ b/adapt/src/main/java/io/noties/adapt/NestedRecyclerState.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 /**
  * @see #process(long, RecyclerView)
- * @since 2.2.0-SNAPSHOT
+ * @since 2.2.0
  */
 public abstract class NestedRecyclerState {
 

--- a/adapt/src/main/java/io/noties/adapt/NestedRecyclerState.java
+++ b/adapt/src/main/java/io/noties/adapt/NestedRecyclerState.java
@@ -1,0 +1,148 @@
+package io.noties.adapt;
+
+import android.annotation.SuppressLint;
+import android.os.Parcelable;
+import android.view.View;
+import android.view.ViewParent;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @see #process(long, RecyclerView)
+ * @since 2.2.0-SNAPSHOT
+ */
+public abstract class NestedRecyclerState {
+
+    /**
+     * Method to save/restore nested RecyclerView state.
+     * Call this in your {@link Item#render(Item.Holder)} method.
+     */
+    public static void process(final long id, @NonNull final RecyclerView recyclerView) {
+
+        final ViewParent parent = recyclerView.getParent();
+        if (parent != null) {
+            // in most cases and during developing, I've noticed that in `render` recycler doesn't have
+            // a parent yet, but it is initialized after render is finished. Anyway, in order to not
+            // miss this case, we will process state here also
+            final Cache cache = Cache.of(parent);
+            cache.restore(id, recyclerView);
+        }
+
+        recyclerView.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+            @Override
+            public void onViewAttachedToWindow(View v) {
+                // restore state
+                Cache.of(recyclerView.getParent()).restore(id, recyclerView);
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View v) {
+                // save state, scroll to 0 position (reset state), and remove onAttachStateListener (self)
+                Cache.of(recyclerView.getParent()).save(id, recyclerView);
+
+                // sometimes a view with recycler is displayed with previous state saved
+                final RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
+                if (layoutManager != null) {
+                    layoutManager.scrollToPosition(0);
+                }
+
+                recyclerView.removeOnAttachStateChangeListener(this);
+            }
+        });
+    }
+
+    /**
+     * Method to clear internal cache in case if RecyclerView will have a completely new set of items
+     * or a new adapter and state must not be persisted. Please note that this will be done
+     * automatically when container is detached from a window.
+     */
+    public static void clear(@NonNull View container) {
+        Cache.of(container).clear();
+    }
+
+    private NestedRecyclerState() {
+    }
+
+    private static class Cache {
+
+        @NonNull
+        static Cache of(@NonNull ViewParent parent) {
+            return of((View) parent);
+        }
+
+        @NonNull
+        static Cache of(@NonNull View container) {
+            Cache cache = (Cache) container.getTag(R.id.adapt_internal_nested_recycler_state_cache);
+            if (cache == null) {
+                cache = new Cache();
+                container.setTag(R.id.adapt_internal_nested_recycler_state_cache, cache);
+                container.addOnAttachStateChangeListener(new DisposeListener(cache));
+            }
+            return cache;
+        }
+
+        // Studio suggests LongSparseArray... it's not generic, is it?
+        // Also, as documentation mentions - sparse array has worse performance that hash-map
+        //  (although it has smaller memory footprint, but speed matters for us more)
+        @SuppressLint("UseSparseArrays")
+        private final Map<Long, Parcelable> cache = new HashMap<>(3);
+
+        void save(long id, @NonNull RecyclerView recyclerView) {
+
+            final Parcelable parcelable;
+
+            final RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
+
+            if (layoutManager != null) {
+                parcelable = layoutManager.onSaveInstanceState();
+            } else {
+                parcelable = null;
+            }
+
+            if (parcelable == null) {
+                // remove it in case there was a previous version
+                cache.remove(id);
+            } else {
+                cache.put(id, parcelable);
+            }
+        }
+
+        void restore(long id, @NonNull RecyclerView recyclerView) {
+            final Parcelable parcelable = cache.remove(id);
+            final RecyclerView.LayoutManager layoutManager = recyclerView.getLayoutManager();
+            if (parcelable != null
+                    && layoutManager != null) {
+                layoutManager.onRestoreInstanceState(parcelable);
+            }
+        }
+
+        void clear() {
+            cache.clear();
+        }
+
+        private static class DisposeListener implements View.OnAttachStateChangeListener {
+
+            private final Cache cache;
+
+            DisposeListener(@NonNull Cache cache) {
+                this.cache = cache;
+            }
+
+            @Override
+            public void onViewAttachedToWindow(View v) {
+                // no op
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View v) {
+                cache.clear();
+                v.removeOnAttachStateChangeListener(this);
+                v.setTag(R.id.adapt_internal_nested_recycler_state_cache, null);
+            }
+        }
+    }
+}

--- a/adapt/src/main/java/io/noties/adapt/StickyItemDecoration.java
+++ b/adapt/src/main/java/io/noties/adapt/StickyItemDecoration.java
@@ -1,0 +1,303 @@
+package io.noties.adapt;
+
+import android.graphics.Canvas;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.FrameLayout;
+import android.widget.HorizontalScrollView;
+import android.widget.ScrollView;
+
+import androidx.annotation.NonNull;
+import androidx.core.view.ScrollingView;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * RecyclerView.ItemDecoration that <em>stick</em> an {@link Item} to the top of a
+ * RecyclerView (aka sticky header or section). Internally uses a duplicated view in layout (data is bound
+ * through {@link AdaptView}). Reverse layout is supported. Also as sticky view is in layout
+ * all widget accessibility features are available. Can be used with GridLayoutManager if sticky view
+ * fills all the spans of GridLayoutManager (matches width).
+ * <p>
+ * Sticky view will always have width equal to RecyclerView width (minus horizontal padding).
+ *
+ * @since 2.2.0-SNAPSHOT
+ */
+public class StickyItemDecoration<I extends Item> extends RecyclerView.ItemDecoration {
+
+    /**
+     * Factory method to create {@link StickyItemDecoration}. Passed {@code item} can be a <em>mocked</em>
+     * one (can have invalid data) - it is just used to create layout only (no render will be called on that item).
+     * Please note that {@code recyclerView} must be wrapped inside a FrameLayout in order to add sticky view.
+     * If you want to provide custom placing of {@link AdaptView} use {@link #create(AdaptView)} or {@link #create(ViewGroup, Item)}.
+     *
+     * @see #create(ViewGroup, Item)
+     * @see #create(AdaptView)
+     */
+    @NonNull
+    public static <I extends Item> StickyItemDecoration<I> create(
+            @NonNull RecyclerView recyclerView,
+            @NonNull I item) {
+        final FrameLayout frameLayout = parentFrameLayout(recyclerView);
+        return create(frameLayout, item);
+    }
+
+    /**
+     * Unlike {@link #create(RecyclerView, Item)} this method does not require FrameLayout as
+     * parent of RecyclerView. Created {@link AdaptView} will be directly added to specified {@code parent}.
+     *
+     * @see #create(RecyclerView, Item)
+     * @see #create(AdaptView)
+     */
+    @NonNull
+    public static <I extends Item> StickyItemDecoration<I> create(
+            @NonNull ViewGroup parent,
+            @NonNull I item) {
+        final AdaptView<I> adaptView = AdaptView.append(parent, item);
+        return create(adaptView);
+    }
+
+    /**
+     * Unlike {@link #create(RecyclerView, Item)} this method does not require FrameLayout
+     * as parent of RecyclerView, but it expects that {@link AdaptView} is already correctly
+     * placed in layout.
+     *
+     * @see #create(RecyclerView, Item)
+     * @see #create(ViewGroup, Item)
+     */
+    @NonNull
+    public static <I extends Item> StickyItemDecoration<I> create(@NonNull AdaptView<I> adaptView) {
+        return new StickyItemDecoration<>(adaptView);
+    }
+
+    // let's make it explicitly FrameLayout
+    @NonNull
+    private static FrameLayout parentFrameLayout(@NonNull RecyclerView recyclerView) {
+
+        final ViewParent parent = recyclerView.getParent();
+
+        // please note... that, for example, ScrollView is a sibling of FrameLayout
+        //      and we must filter those...
+
+        final boolean isFrame = parent instanceof FrameLayout;
+
+        // so, ScrollView, HorizontalScrollView (they kinda weird to see here, who would
+        // want to do so)? Also... there are NestedScrollViews...
+        final boolean isScroll = isFrame && (parent instanceof ScrollView
+                || parent instanceof HorizontalScrollView
+                || parent instanceof ScrollingView);
+
+        if (isFrame && !isScroll) {
+            return (FrameLayout) parent;
+        }
+
+        throw AdaptException.create("RecyclerView must be placed inside FrameLayout " +
+                "in order to add sticky view. Consider wrapping RecyclerView inside FrameLayout " +
+                "or use different #create factory method that allows manual placing of sticky view.");
+    }
+
+    protected static final int MEASURE_SPEC_UNSPECIFIED =
+            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+
+    private final AdaptView<I> adaptView;
+    private final int stickyViewType;
+
+    protected StickyItemDecoration(@NonNull AdaptView<I> adaptView) {
+        this.adaptView = adaptView;
+        this.stickyViewType = Item.generatedViewType(adaptView.getCurrentItem().getClass());
+        hideStickyView();
+    }
+
+    @Override
+    public void onDrawOver(@NonNull Canvas c, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+
+        // we must have children
+        final int count = parent.getChildCount();
+        if (count == 0) {
+            hideStickyView();
+            return;
+        }
+
+        // layout manager must be present
+        final RecyclerView.LayoutManager layoutManager = parent.getLayoutManager();
+        if (layoutManager == null) {
+            hideStickyView();
+            return;
+        }
+
+        if (isReverseLayout(layoutManager)) {
+            processReverseLayout(parent);
+        } else {
+            processRegularLayout(parent);
+        }
+    }
+
+    protected boolean isReverseLayout(@NonNull RecyclerView.LayoutManager layoutManager) {
+        return layoutManager instanceof LinearLayoutManager
+                && ((LinearLayoutManager) layoutManager).getReverseLayout();
+    }
+
+    protected void processRegularLayout(@NonNull RecyclerView parent) {
+
+        final View first = parent.getChildAt(0);
+        final RecyclerView.ViewHolder holder = parent.findContainingViewHolder(first);
+
+        // cannot do anything here
+        if (holder == null) {
+            hideStickyView();
+            return;
+        }
+
+        final RecyclerView.Adapter adapter = parent.getAdapter();
+        if (!(adapter instanceof Adapt)) {
+            hideStickyView();
+            return;
+        }
+
+        final Adapt adapt = (Adapt) adapter;
+
+        int position = holder.getAdapterPosition();
+        I item = null;
+
+        while (position >= 0) {
+            if (stickyViewType == adapt.getItemViewType(position)) {
+                //noinspection unchecked
+                item = (I) adapt.getItem(position);
+                break;
+            }
+            position -= 1;
+        }
+
+        if (item == null) {
+            hideStickyView();
+            return;
+        }
+
+        position += 1;
+
+        int nextStickyViewTop = 0;
+        final int adapterCount = adapt.getItemCount();
+
+        while (position < adapterCount) {
+            if (stickyViewType == adapt.getItemViewType(position)) {
+                final RecyclerView.ViewHolder viewHolder = parent.findViewHolderForAdapterPosition(position);
+                nextStickyViewTop = viewHolder != null
+                        ? viewHolder.itemView.getTop()
+                        : 0;
+                break;
+            }
+            position += 1;
+        }
+
+        adaptView.setItem(item);
+
+        final View view = prepareStickyView(adaptView, parent);
+        view.setAlpha(1F);
+
+        final int height = view.getMeasuredHeight();
+        final float y;
+        if (nextStickyViewTop > 0 && nextStickyViewTop < height) {
+            y = -(height - nextStickyViewTop);
+            processStickyView(view, (float) nextStickyViewTop / height);
+        } else {
+            y = 0F;
+            processStickyView(view, 1F);
+        }
+        view.setTranslationY(y);
+    }
+
+    protected void processReverseLayout(@NonNull RecyclerView parent) {
+        final LinearLayoutManager manager = (LinearLayoutManager) parent.getLayoutManager();
+        if (manager == null) {
+            hideStickyView();
+            return;
+        }
+
+        // returns adapter position
+        int position = manager.findLastVisibleItemPosition();
+        if (position < 0) {
+            // -1
+            hideStickyView();
+            return;
+        }
+
+        final RecyclerView.Adapter adapter = parent.getAdapter();
+        if (!(adapter instanceof Adapt)) {
+            hideStickyView();
+            return;
+        }
+
+        final Adapt adapt = (Adapt) adapter;
+        final int adaptCount = adapt.getItemCount();
+
+        I item = null;
+
+        // okay, from this point we iterate forward to find next sticky item
+        while (position < adaptCount) {
+            if (stickyViewType == adapt.getItemViewType(position)) {
+                //noinspection unchecked
+                item = (I) adapt.getItem(position);
+                break;
+            }
+            position += 1;
+        }
+
+        if (item == null) {
+            hideStickyView();
+            return;
+        }
+
+        position -= 1;
+
+        int previousStickyViewTop = 0;
+        while (position >= 0) {
+            if (stickyViewType == adapt.getItemViewType(position)) {
+                final RecyclerView.ViewHolder viewHolder = parent.findViewHolderForAdapterPosition(position);
+                previousStickyViewTop = viewHolder != null
+                        ? viewHolder.itemView.getTop()
+                        : 0;
+                break;
+            }
+            position -= 1;
+        }
+
+        adaptView.setItem(item);
+
+        final View view = prepareStickyView(adaptView, parent);
+        view.setAlpha(1F);
+
+        final int height = view.getHeight();
+        final int y;
+        if (previousStickyViewTop > 0 && previousStickyViewTop < height) {
+            y = -(height - previousStickyViewTop);
+            processStickyView(view, (float) previousStickyViewTop / height);
+        } else {
+            y = 0;
+            processStickyView(view, 1F);
+        }
+        view.setTranslationY(y);
+    }
+
+    @NonNull
+    protected View prepareStickyView(@NonNull AdaptView<I> adaptView, @NonNull RecyclerView recyclerView) {
+        final int left = recyclerView.getPaddingLeft();
+        final int width = recyclerView.getWidth() - left - recyclerView.getPaddingRight();
+        final View view = adaptView.view();
+        view.measure(
+                View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
+                MEASURE_SPEC_UNSPECIFIED
+        );
+        view.layout(left, 0, left + view.getMeasuredWidth(), view.getMeasuredHeight());
+        return view;
+    }
+
+    // 1F - is fully sticky, 0F - completely not
+    protected void processStickyView(@NonNull View view, float ratio) {
+
+    }
+
+    protected void hideStickyView() {
+        adaptView.view().setAlpha(0F);
+    }
+}

--- a/adapt/src/main/java/io/noties/adapt/StickyItemDecoration.java
+++ b/adapt/src/main/java/io/noties/adapt/StickyItemDecoration.java
@@ -22,7 +22,7 @@ import androidx.recyclerview.widget.RecyclerView;
  * <p>
  * Sticky view will always have width equal to RecyclerView width (minus horizontal padding).
  *
- * @since 2.2.0-SNAPSHOT
+ * @since 2.2.0
  */
 public class StickyItemDecoration<I extends Item> extends RecyclerView.ItemDecoration {
 

--- a/adapt/src/main/res/values/ids.xml
+++ b/adapt/src/main/res/values/ids.xml
@@ -3,5 +3,6 @@
 
     <item name="adapt_internal_item" type="id" />
     <item name="adapt_internal_holder" type="id" />
+    <item name="adapt_internal_nested_recycler_state_cache" type="id" />
 
 </resources>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx4g
 
-VERSION_NAME=2.1.0
+VERSION_NAME=2.2.0-SNAPSHOT
 
 GROUP=io.noties
 POM_DESCRIPTION=Adapt

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx4g
 
-VERSION_NAME=2.2.0-SNAPSHOT
+VERSION_NAME=2.2.0
 
 GROUP=io.noties
 POM_DESCRIPTION=Adapt

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()
@@ -31,7 +31,7 @@ dependencies {
 
     implementation project(':adapt')
 
-    implementation 'io.noties:debug:5.0.0@jar'
+    implementation 'io.noties:debug:5.1.0'
     implementation 'com.google.android:flexbox:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
         <activity android:name=".screen.flex.AdaptFlexActivity" />
         <activity android:name=".screen.linear.AdaptLinearRecyclerActivity" />
         <activity android:name=".screen.view.AdaptViewActivity" />
+        <activity android:name=".screen.nestedrecycler.NestedRecyclerActivity" />
 
     </application>
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
         <activity android:name=".screen.linear.AdaptLinearRecyclerActivity" />
         <activity android:name=".screen.view.AdaptViewActivity" />
         <activity android:name=".screen.nestedrecycler.NestedRecyclerActivity" />
+        <activity android:name=".screen.nestedrecyclersuper.NestedRecyclerSuperActivity" />
 
     </application>
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
         <activity android:name=".screen.view.AdaptViewActivity" />
         <activity android:name=".screen.nestedrecycler.NestedRecyclerActivity" />
         <activity android:name=".screen.nestedrecyclersuper.NestedRecyclerSuperActivity" />
+        <activity android:name=".screen.stickyheader.StickyHeaderActivity" />
 
     </application>
 

--- a/sample/src/main/java/io/noties/adapt/sample/MainActivity.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/MainActivity.kt
@@ -14,6 +14,7 @@ import io.noties.adapt.sample.screen.group.AdaptViewGroupActivity
 import io.noties.adapt.sample.screen.linear.AdaptLinearRecyclerActivity
 import io.noties.adapt.sample.screen.nestedrecycler.NestedRecyclerActivity
 import io.noties.adapt.sample.screen.nestedrecyclersuper.NestedRecyclerSuperActivity
+import io.noties.adapt.sample.screen.stickyheader.StickyHeaderActivity
 import io.noties.adapt.sample.screen.view.AdaptViewActivity
 import io.noties.debug.AndroidLogDebugOutput
 import io.noties.debug.Debug
@@ -25,7 +26,8 @@ enum class Screen(val activity: Class<out Activity>, val title: String, val desc
     FLEX_VIEW_GROUP(AdaptFlexActivity::class.java, "FlexLayout", "Usage with a FlexLayout in a ViewGroup context"),
     VIEW(AdaptViewActivity::class.java, "View", "Usage with a regular View (bind Item)"),
     NESTED_RECYCLER(NestedRecyclerActivity::class.java, "Nested RecyclerView items", "Usage of nested RecyclerView in items"),
-    NESTED_RECYCLER_SUPER(NestedRecyclerSuperActivity::class.java, "Nested RecyclerView super (2 levels)", "Usage of deeply nested recycler views (2 levels deep)")
+    NESTED_RECYCLER_SUPER(NestedRecyclerSuperActivity::class.java, "Nested RecyclerView super (2 levels)", "Usage of deeply nested recycler views (2 levels deep)"),
+    STICKY_HEADER(StickyHeaderActivity::class.java, "Sticky Header", "Sample RecyclerView with sticky header")
 }
 
 class MainActivity : Activity() {

--- a/sample/src/main/java/io/noties/adapt/sample/MainActivity.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/MainActivity.kt
@@ -13,6 +13,7 @@ import io.noties.adapt.sample.screen.grid.AdaptGridActivity
 import io.noties.adapt.sample.screen.group.AdaptViewGroupActivity
 import io.noties.adapt.sample.screen.linear.AdaptLinearRecyclerActivity
 import io.noties.adapt.sample.screen.nestedrecycler.NestedRecyclerActivity
+import io.noties.adapt.sample.screen.nestedrecyclersuper.NestedRecyclerSuperActivity
 import io.noties.adapt.sample.screen.view.AdaptViewActivity
 import io.noties.debug.AndroidLogDebugOutput
 import io.noties.debug.Debug
@@ -23,7 +24,8 @@ enum class Screen(val activity: Class<out Activity>, val title: String, val desc
     VIEW_GROUP(AdaptViewGroupActivity::class.java, "ViewGroup", "Usage in a ViewGroup"),
     FLEX_VIEW_GROUP(AdaptFlexActivity::class.java, "FlexLayout", "Usage with a FlexLayout in a ViewGroup context"),
     VIEW(AdaptViewActivity::class.java, "View", "Usage with a regular View (bind Item)"),
-    NESTED_RECYCLER(NestedRecyclerActivity::class.java, "Nested RecyclerView items", "Usage of nested RecyclerView in items")
+    NESTED_RECYCLER(NestedRecyclerActivity::class.java, "Nested RecyclerView items", "Usage of nested RecyclerView in items"),
+    NESTED_RECYCLER_SUPER(NestedRecyclerSuperActivity::class.java, "Nested RecyclerView super (2 levels)", "Usage of deeply nested recycler views (2 levels deep)")
 }
 
 class MainActivity : Activity() {

--- a/sample/src/main/java/io/noties/adapt/sample/MainActivity.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/MainActivity.kt
@@ -12,6 +12,7 @@ import io.noties.adapt.sample.screen.flex.AdaptFlexActivity
 import io.noties.adapt.sample.screen.grid.AdaptGridActivity
 import io.noties.adapt.sample.screen.group.AdaptViewGroupActivity
 import io.noties.adapt.sample.screen.linear.AdaptLinearRecyclerActivity
+import io.noties.adapt.sample.screen.nestedrecycler.NestedRecyclerActivity
 import io.noties.adapt.sample.screen.view.AdaptViewActivity
 import io.noties.debug.AndroidLogDebugOutput
 import io.noties.debug.Debug
@@ -21,7 +22,8 @@ enum class Screen(val activity: Class<out Activity>, val title: String, val desc
     GRID(AdaptGridActivity::class.java, "Recycler Grid", "Usage in RecyclerView with GridLayoutManager"),
     VIEW_GROUP(AdaptViewGroupActivity::class.java, "ViewGroup", "Usage in a ViewGroup"),
     FLEX_VIEW_GROUP(AdaptFlexActivity::class.java, "FlexLayout", "Usage with a FlexLayout in a ViewGroup context"),
-    VIEW(AdaptViewActivity::class.java, "View", "Usage with a regular View (bind Item)")
+    VIEW(AdaptViewActivity::class.java, "View", "Usage with a regular View (bind Item)"),
+    NESTED_RECYCLER(NestedRecyclerActivity::class.java, "Nested RecyclerView items", "Usage of nested RecyclerView in items")
 }
 
 class MainActivity : Activity() {

--- a/sample/src/main/java/io/noties/adapt/sample/screen/grid/AdaptGridActivity.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/screen/grid/AdaptGridActivity.kt
@@ -52,12 +52,4 @@ class AdaptGridActivity : BaseSampleActivity() {
 
         addMoreItems()
     }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-
-        if (isFinishing) {
-            overridePendingTransition(R.anim.out_appear, R.anim.out_disappear)
-        }
-    }
 }

--- a/sample/src/main/java/io/noties/adapt/sample/screen/nestedrecycler/NestedRecyclerActivity.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/screen/nestedrecycler/NestedRecyclerActivity.kt
@@ -1,0 +1,66 @@
+package io.noties.adapt.sample.screen.nestedrecycler
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import io.noties.adapt.Adapt
+import io.noties.adapt.DiffUtilDataSetChanged
+import io.noties.adapt.Item
+import io.noties.adapt.ItemGroup
+import io.noties.adapt.ItemLayoutWrapper
+import io.noties.adapt.sample.ItemGenerator
+import io.noties.adapt.sample.R
+import io.noties.adapt.sample.screen.BaseSampleActivity
+
+class NestedRecyclerActivity : BaseSampleActivity() {
+
+    override fun layoutResId() = R.layout.activity_recycler
+
+    override fun title() = "RecyclerView Nested items"
+
+    override fun addMoreItems() {
+        val items = adapt.currentItems.toMutableList().apply {
+            add(NestedItemGroup(count().toLong(), generator.generate(10).map {
+                // wrap in a framelayout that limits size and adds padding
+                ItemLayoutWrapper.create(R.layout.item_frame, it)
+            }))
+        }
+        adapt.setItems(items)
+    }
+
+    override fun shuffleItems() {
+        adapt.setItems(generator.shuffle(adapt.currentItems))
+    }
+
+    private val adapt = Adapt.create(DiffUtilDataSetChanged.create())
+    private val generator = ItemGenerator()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val recycler = findViewById<RecyclerView>(R.id.recycler_view)
+        recycler.layoutManager = LinearLayoutManager(this)
+        recycler.setHasFixedSize(true)
+
+        recycler.adapter = adapt
+
+        addMoreItems()
+    }
+}
+
+class NestedItemGroup(id: Long, children: List<Item<*>>) : ItemGroup(id, children) {
+
+    override fun createView(inflater: LayoutInflater, parent: ViewGroup): View {
+        return inflater.inflate(R.layout.item_nested_recycler, parent, false)
+    }
+
+    override fun initNestedRecyclerView(view: View): RecyclerView {
+        val recyclerView = view.findViewById<RecyclerView>(R.id.recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(view.context, LinearLayoutManager.HORIZONTAL, false)
+        recyclerView.setHasFixedSize(true)
+        return recyclerView
+    }
+}

--- a/sample/src/main/java/io/noties/adapt/sample/screen/nestedrecyclersuper/NestedRecyclerSuperActivity.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/screen/nestedrecyclersuper/NestedRecyclerSuperActivity.kt
@@ -1,0 +1,109 @@
+package io.noties.adapt.sample.screen.nestedrecyclersuper
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import io.noties.adapt.AdaptViewGroup
+import io.noties.adapt.Item
+import io.noties.adapt.ItemGroup
+import io.noties.adapt.ItemLayoutWrapper
+import io.noties.adapt.sample.ItemGenerator
+import io.noties.adapt.sample.R
+import io.noties.adapt.sample.screen.BaseSampleActivity
+
+class NestedRecyclerSuperActivity : BaseSampleActivity() {
+
+    override fun layoutResId() = R.layout.activity_nested_super
+
+    override fun title() = "Super nested RecyclerView"
+
+    override fun addMoreItems() {
+        val items = group.currentItems.toMutableList().apply {
+            // add horizontal items which will have vertical items
+            val vertical = List(6) {
+                VerticalItemGroup(it.toLong(), generator.generate(6).map { item ->
+                    // wrap in frame layout with width/height limited
+                    ItemLayoutWrapper.create(R.layout.item_frame, item)
+                })
+            }
+            add(HorizontalItemGroup(recyclerViewPool, count().toLong(), vertical))
+        }
+        group.setItems(items)
+    }
+
+    override fun shuffleItems() {
+        group.setItems(generator.shuffle(group.currentItems))
+    }
+
+    private lateinit var group: AdaptViewGroup
+
+    //    private val adapt = Adapt.create()
+    private val generator = ItemGenerator()
+    private val recyclerViewPool = RecyclerView.RecycledViewPool()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // unfortunately the last level (vertical) doesn't work if our root is RecyclerView
+        // most likely there is a hack to work-around it... but it should never be so -
+        //      a vertical recycler-view inside another vertical recycler-view
+
+        // another thing -> as we no longer inside a recycler view, we must manually set recycler-view-pool
+        // currently this pool is reused only in horizontal item, but we want all horizontal items
+        // also share it
+
+//        val recyclerView = findViewById<RecyclerView>(R.id.recycler_view)
+//        recyclerView.layoutManager = LinearLayoutManager(this) // VERTICAL
+//        recyclerView.setHasFixedSize(true)
+//        recyclerView.isNestedScrollingEnabled = false
+//
+//        recyclerView.adapter = adapt
+
+        group = AdaptViewGroup.create(findViewById(R.id.view_group))
+
+        addMoreItems()
+    }
+}
+
+// 1-st level - HORIZONTAL
+class HorizontalItemGroup(
+        private val pool: RecyclerView.RecycledViewPool,
+        id: Long,
+        children: List<Item<*>>
+) : ItemGroup(id, children) {
+    override fun createView(inflater: LayoutInflater, parent: ViewGroup): View {
+        return inflater.inflate(R.layout.item_nested_recycler_horizontal, parent, false)
+    }
+
+    override fun initNestedRecyclerView(view: View): RecyclerView {
+        val recyclerView = view.findViewById<RecyclerView>(R.id.recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(view.context, LinearLayoutManager.HORIZONTAL, false)
+        return recyclerView
+    }
+
+    override fun processRecyclerViewPool(parent: ViewGroup, recyclerView: RecyclerView) {
+        // default implementation just uses parent view pool if it's a recycler view
+        // it is no longer the case in this example, so we manually apply the pool that we'd
+        // received in constructor
+        //
+        // please note that we do not need to do it for vertical item, as it will automatically
+        // use this pool also
+        recyclerView.setRecycledViewPool(pool)
+    }
+}
+
+// 2-nd level VERTICAL
+class VerticalItemGroup(id: Long, children: List<Item<*>>) : ItemGroup(id, children) {
+    override fun createView(inflater: LayoutInflater, parent: ViewGroup): View {
+        return inflater.inflate(R.layout.item_nested_recycler_vertical, parent, false)
+    }
+
+    override fun initNestedRecyclerView(view: View): RecyclerView {
+        val recyclerView = view.findViewById<RecyclerView>(R.id.recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(view.context)
+        return recyclerView
+    }
+}

--- a/sample/src/main/java/io/noties/adapt/sample/screen/stickyheader/HeaderItem.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/screen/stickyheader/HeaderItem.kt
@@ -1,0 +1,31 @@
+package io.noties.adapt.sample.screen.stickyheader
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import io.noties.adapt.Item
+import io.noties.adapt.StickyItemDecoration
+import io.noties.adapt.sample.R
+
+class HeaderItem(private val text: CharSequence) : Item<HeaderItem.Holder>(text.hashCode().toLong()) {
+
+    override fun createHolder(inflater: LayoutInflater, parent: ViewGroup): Holder {
+        return Holder(inflater.inflate(R.layout.item_header, parent, false))
+    }
+
+    override fun render(holder: Holder) {
+        holder.textView.text = text
+    }
+
+    override fun recyclerDecoration(recyclerView: RecyclerView): RecyclerView.ItemDecoration? {
+        // calling this factory method means that our RecyclerView is wrapped inside FrameLayout
+        // if it's not possible/desired use a different method with AdaptView manually placed in layout
+        return StickyItemDecoration.create(recyclerView, this)
+    }
+
+    class Holder(view: View) : Item.Holder(view) {
+        val textView = requireView<TextView>(R.id.text)
+    }
+}

--- a/sample/src/main/java/io/noties/adapt/sample/screen/stickyheader/StickyHeaderActivity.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/screen/stickyheader/StickyHeaderActivity.kt
@@ -1,0 +1,76 @@
+package io.noties.adapt.sample.screen.stickyheader
+
+import android.os.Bundle
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import io.noties.adapt.Adapt
+import io.noties.adapt.Item
+import io.noties.adapt.sample.ItemGenerator
+import io.noties.adapt.sample.R
+import io.noties.adapt.sample.screen.BaseSampleActivity
+
+class StickyHeaderActivity : BaseSampleActivity() {
+
+    override fun layoutResId() = R.layout.activity_recycler
+
+    override fun title() = "Sticky header"
+
+    override fun addMoreItems() {
+        val items = adapt.currentItems.toMutableList().apply {
+            // ignore first to show that no header is drawn until the first one is pushed out of screen
+            if (headers != 0) {
+                // header 3 will have multiple lines
+                add(HeaderItem("HEADER $headers ${if (headers == 3) "\n\nyo!" else ""}"))
+            }
+            headers += 1
+            addAll(List(9) {
+                TextItem("Item ${count() + it}")
+            })
+        }
+        adapt.setItems(items)
+    }
+
+    override fun shuffleItems() {
+        adapt.setItems(generator.shuffle(adapt.currentItems))
+    }
+
+    private val adapt = Adapt.create()
+    private val generator = ItemGenerator() // will be used only to shuffle
+
+    private var headers = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val recyclerView = findViewById<RecyclerView>(R.id.recycler_view)
+        recyclerView.setHasFixedSize(true)
+
+//        recyclerView.setPadding(
+//                48, 48, 48, 48
+//        )
+//        recyclerView.clipToPadding = false
+
+        recyclerView.layoutManager = LinearLayoutManager(this)
+
+        // reverse layout is available
+//        recyclerView.layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, true)
+
+        // works with grid-layout-manager also
+        // just be sure to set span count of header to fill all grids
+//        val manager = GridLayoutManager(this, 3)
+//        manager.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
+//
+//            val header = Item.generatedViewType(HeaderItem::class.java)
+//
+//            override fun getSpanSize(position: Int): Int {
+//                return if (adapt.getItemViewType(position) == header) 3 else 1
+//            }
+//        }
+//        recyclerView.layoutManager = manager
+
+        recyclerView.adapter = adapt
+
+        addMoreItems()
+    }
+}

--- a/sample/src/main/java/io/noties/adapt/sample/screen/stickyheader/TextItem.kt
+++ b/sample/src/main/java/io/noties/adapt/sample/screen/stickyheader/TextItem.kt
@@ -1,0 +1,23 @@
+package io.noties.adapt.sample.screen.stickyheader
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import io.noties.adapt.Item
+import io.noties.adapt.sample.R
+
+class TextItem(private val text: CharSequence): Item<TextItem.Holder>(text.hashCode().toLong()) {
+
+    override fun createHolder(inflater: LayoutInflater, parent: ViewGroup): Holder {
+        return Holder(inflater.inflate(R.layout.item_text, parent, false))
+    }
+
+    override fun render(holder: Holder) {
+        holder.textView.text = text
+    }
+
+    class Holder(view: View): Item.Holder(view) {
+        val textView = requireView<TextView>(R.id.text)
+    }
+}

--- a/sample/src/main/res/drawable/bg_item_header.xml
+++ b/sample/src/main/res/drawable/bg_item_header.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#ccc" />
+    <stroke
+        android:width="1dip"
+        android:color="#000" />
+</shape>

--- a/sample/src/main/res/layout/activity_nested_super.xml
+++ b/sample/src/main/res/layout/activity_nested_super.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include layout="@layout/include_app_bar" />
+
+    <LinearLayout
+        android:id="@+id/view_group"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical" />
+
+</LinearLayout>

--- a/sample/src/main/res/layout/activity_recycler.xml
+++ b/sample/src/main/res/layout/activity_recycler.xml
@@ -6,10 +6,16 @@
 
     <include layout="@layout/include_app_bar" />
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recycler_view"
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:overScrollMode="never" />
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recycler_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:overScrollMode="never" />
+
+    </FrameLayout>
 
 </LinearLayout>

--- a/sample/src/main/res/layout/item_frame.xml
+++ b/sample/src/main/res/layout/item_frame.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="128dip"
+    android:layout_height="128dip"
+    android:padding="8dip" />

--- a/sample/src/main/res/layout/item_header.xml
+++ b/sample/src/main/res/layout/item_header.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/text"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_item_header"
+    android:padding="8dip"
+    android:textAppearance="?android:attr/textAppearanceLarge"
+    tools:text="Hello there!" />

--- a/sample/src/main/res/layout/item_nested_recycler.xml
+++ b/sample/src/main/res/layout/item_nested_recycler.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/recycler_view"
+    android:layout_width="match_parent"
+    android:layout_height="128dip"
+    android:clipToPadding="false"
+    android:paddingStart="64dip"
+    tools:ignore="RtlSymmetry" />

--- a/sample/src/main/res/layout/item_nested_recycler_horizontal.xml
+++ b/sample/src/main/res/layout/item_nested_recycler_horizontal.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recycler_view"
+    android:layout_width="match_parent"
+    android:layout_height="128dip" />

--- a/sample/src/main/res/layout/item_nested_recycler_vertical.xml
+++ b/sample/src/main/res/layout/item_nested_recycler_vertical.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recycler_view"
+    android:layout_width="128dip"
+    android:layout_height="match_parent" />

--- a/sample/src/main/res/layout/item_text.xml
+++ b/sample/src/main/res/layout/item_text.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/text"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dip"
+    android:textAppearance="?android:attr/textAppearanceListItem"
+    tools:text="Hello my dear text!" />


### PR DESCRIPTION
* create `ItemGroup` for easier nested RecyclerView support
* create `ItemLayoutWrapper` for easier wrapping of an `Item` inside a different layout
* add `HasWrappedItem` interface (2 implementations - `ItemWrapper` and `ItemLayoutWrapper`)
* utility to automatically process nested RecyclerView state - `NestedRecyclerState`
* add `Adapt#getItem(position)` method
* add `AdaptView#view()` method
* add `StickyItemDecoration` for sticky headers/sections